### PR TITLE
Fix repeated

### DIFF
--- a/leg_detector/src/leg_detector.cpp
+++ b/leg_detector/src/leg_detector.cpp
@@ -138,8 +138,11 @@ public:
 
   void update(tf::Stamped<tf::Point> loc, double probability)
   {
-    tf::StampedTransform pose(tf::Pose(tf::Quaternion(0.0, 0.0, 0.0, 1.0), loc), loc.stamp_, loc.frame_id_, id_);
-    tfl_.setTransform(pose);
+    if (loc.stamp_ > meas_time_)
+    {
+      tf::StampedTransform pose(tf::Pose(tf::Quaternion(0.0, 0.0, 0.0, 1.0), loc), loc.stamp_, loc.frame_id_, id_);
+      tfl_.setTransform(pose);
+    }
 
     meas_time_ = loc.stamp_;
     time_ = meas_time_;

--- a/leg_detector/src/leg_detector.cpp
+++ b/leg_detector/src/leg_detector.cpp
@@ -138,11 +138,12 @@ public:
 
   void update(tf::Stamped<tf::Point> loc, double probability)
   {
-    if (loc.stamp_ > meas_time_)
+    if (loc.stamp_ <= meas_time_)
     {
-      tf::StampedTransform pose(tf::Pose(tf::Quaternion(0.0, 0.0, 0.0, 1.0), loc), loc.stamp_, loc.frame_id_, id_);
-      tfl_.setTransform(pose);
+      loc.stamp_ = meas_time_ + ros::Duration(0.0001);
     }
+    tf::StampedTransform pose(tf::Pose(tf::Quaternion(0.0, 0.0, 0.0, 1.0), loc), loc.stamp_, loc.frame_id_, id_);
+    tfl_.setTransform(pose);
 
     meas_time_ = loc.stamp_;
     time_ = meas_time_;


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary

こんな感じで人を重ねると再現できたので修正しました。
[ac1d224](https://github.com/sbgisen/people/pull/5/commits/ac1d224f7380afaa71a32707b8f80ab68156af6d) は明らかに検出精度が下がったので、
[9ea6781](https://github.com/sbgisen/people/pull/5/commits/9ea6781605d973248c9543d195a742dee323fe94) でtimestampを微量にずらすようにしました。
![Screenshot from 2024-05-31 14-06-02](https://github.com/sbgisen/people/assets/13605820/daf32ce6-9fc3-4e9a-a242-35ceb22e8814)

<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->
- fix #4 

<!-- 変更の詳細 -->
## Detail

<!-- この関数を変更したのでこの機能にも影響がある、など -->
## Impact

<!-- どのような動作検証を行ったか -->
## Test

<!-- ROS package向け Template

* [ ] ビルドが通った
* [ ] gazebo環境で動作した
* [ ] 実機環境で動作した
* [ ] (アプリ名)で動作検証した

-->

## Attention
<!-- 上記項目以外の補足情報など
例
- レビューをする際に見てほしい点
- ローカル環境で試す際の注意点
- このPull Requestよりも先にマージしなければならないPull Request
- 複数レビュワー指定している場合に、レビュー必須の人(いれば)の指定 -->
